### PR TITLE
Required Database Changes

### DIFF
--- a/database/schema_table_creation.sql
+++ b/database/schema_table_creation.sql
@@ -31,16 +31,6 @@ create table if not exists anonymous_usage_events (
   event_loaded_at timestamp default sysdate() -- this is the utc timestamp
 );
 
-create sequence if not exists keys_id_seq start = 1 increment = 1;
-
-create table if not exists api_keys (
-  id integer,
-  api_key varchar,
-  client_id varchar,
-  created_at timestamp_tz,
-  expired_at timestamp_tz
-);
-
 create sequence if not exists mapping_id_seq start = 1 increment = 1;
 
 create table if not exists cli_api_mapping (


### PR DESCRIPTION
Closes #17

This PR is a catch-all for any required database changes found in the initial development of fideslog.

These changes should be applied to the database as soon as possible and housed in here. This will ship when the remaining initial work for fideslog is complete

Changes:
* [x] Change `autoincrement` ids across tables to use a `sequence` in line with Snowflake docs
* [x] Change types of `resource_counts`, `flags`, and `extra_data` to `varchar` due to `orm` method not supporting those types in Snowflake
* [x] Remove the `api_keys` table as it is not required