### PR TITLE
update MANIFEST.in to incude requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
-include versioneer.py
+include dev-requirements.txt
 include fideslog/sdk/python/_version.py
+include fideslog/sdk/python/requirements.txt
+include versioneer.py


### PR DESCRIPTION
Closes #30 

After cutting the initial `v0.9.0` a `pip install fideslog` failed due to missing `requirements.txt`

Building the source distribution locally showed that the requirements files were not included. With this change, we can now see that both of the `dev-requirements.txt` and `requirements.txt` are distributed correctly.

Before changes to `MANIFEST.in`:
```bash
running sdist
running egg_info
writing fideslog.egg-info/PKG-INFO
writing dependency_links to fideslog.egg-info/dependency_links.txt
writing requirements to fideslog.egg-info/requires.txt
writing top-level names to fideslog.egg-info/top_level.txt
reading manifest file 'fideslog.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'fideslog.egg-info/SOURCES.txt'
running check
creating fideslog-0.9.0
creating fideslog-0.9.0/fideslog
creating fideslog-0.9.0/fideslog.egg-info
creating fideslog-0.9.0/fideslog/sdk
creating fideslog-0.9.0/fideslog/sdk/python
copying files to fideslog-0.9.0...
copying LICENSE -> fideslog-0.9.0
copying MANIFEST.in -> fideslog-0.9.0
copying README.md -> fideslog-0.9.0
copying pyproject.toml -> fideslog-0.9.0
copying setup.cfg -> fideslog-0.9.0
copying setup.py -> fideslog-0.9.0
copying versioneer.py -> fideslog-0.9.0
copying fideslog/__init__.py -> fideslog-0.9.0/fideslog
copying fideslog.egg-info/PKG-INFO -> fideslog-0.9.0/fideslog.egg-info
copying fideslog.egg-info/SOURCES.txt -> fideslog-0.9.0/fideslog.egg-info
copying fideslog.egg-info/dependency_links.txt -> fideslog-0.9.0/fideslog.egg-info
copying fideslog.egg-info/requires.txt -> fideslog-0.9.0/fideslog.egg-info
copying fideslog.egg-info/top_level.txt -> fideslog-0.9.0/fideslog.egg-info
copying fideslog/sdk/python/__init__.py -> fideslog-0.9.0/fideslog/sdk/python
copying fideslog/sdk/python/_version.py -> fideslog-0.9.0/fideslog/sdk/python
copying fideslog/sdk/python/client.py -> fideslog-0.9.0/fideslog/sdk/python
copying fideslog/sdk/python/event.py -> fideslog-0.9.0/fideslog/sdk/python
copying fideslog/sdk/python/exceptions.py -> fideslog-0.9.0/fideslog/sdk/python
copying fideslog/sdk/python/utils.py -> fideslog-0.9.0/fideslog/sdk/python
Writing fideslog-0.9.0/setup.cfg
UPDATING fideslog-0.9.0/fideslog/sdk/python/_version.py
set fideslog-0.9.0/fideslog/sdk/python/_version.py to 'v0.9.0'
Creating tar archive
removing 'fideslog-0.9.0' (and everything under it)
```

After changes to `MANIFEST.in`:
```bash
running sdist
running egg_info
writing fideslog.egg-info/PKG-INFO
writing dependency_links to fideslog.egg-info/dependency_links.txt
writing requirements to fideslog.egg-info/requires.txt
writing top-level names to fideslog.egg-info/top_level.txt
reading manifest file 'fideslog.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'fideslog.egg-info/SOURCES.txt'
running check
creating fideslog-0.9.0+0.g1fb830a.dirty
creating fideslog-0.9.0+0.g1fb830a.dirty/fideslog
creating fideslog-0.9.0+0.g1fb830a.dirty/fideslog.egg-info
creating fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk
creating fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying files to fideslog-0.9.0+0.g1fb830a.dirty...
copying LICENSE -> fideslog-0.9.0+0.g1fb830a.dirty
copying MANIFEST.in -> fideslog-0.9.0+0.g1fb830a.dirty
copying README.md -> fideslog-0.9.0+0.g1fb830a.dirty
copying dev-requirements.txt -> fideslog-0.9.0+0.g1fb830a.dirty
copying pyproject.toml -> fideslog-0.9.0+0.g1fb830a.dirty
copying setup.cfg -> fideslog-0.9.0+0.g1fb830a.dirty
copying setup.py -> fideslog-0.9.0+0.g1fb830a.dirty
copying versioneer.py -> fideslog-0.9.0+0.g1fb830a.dirty
copying fideslog/__init__.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog
copying fideslog.egg-info/PKG-INFO -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog.egg-info
copying fideslog.egg-info/SOURCES.txt -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog.egg-info
copying fideslog.egg-info/dependency_links.txt -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog.egg-info
copying fideslog.egg-info/requires.txt -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog.egg-info
copying fideslog.egg-info/top_level.txt -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog.egg-info
copying fideslog/sdk/python/__init__.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying fideslog/sdk/python/_version.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying fideslog/sdk/python/client.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying fideslog/sdk/python/event.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying fideslog/sdk/python/exceptions.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying fideslog/sdk/python/requirements.txt -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
copying fideslog/sdk/python/utils.py -> fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python
Writing fideslog-0.9.0+0.g1fb830a.dirty/setup.cfg
UPDATING fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python/_version.py
set fideslog-0.9.0+0.g1fb830a.dirty/fideslog/sdk/python/_version.py to 'v0.9.0+0.g1fb830a.dirty'
Creating tar archive
removing 'fideslog-0.9.0+0.g1fb830a.dirty' (and everything under it)
```