### PR TITLE
Use the production API server URL

### DIFF
--- a/fideslog/sdk/python/client.py
+++ b/fideslog/sdk/python/client.py
@@ -16,6 +16,8 @@ class AnalyticsClient:
     analytics events to the fideslog server.
     """
 
+    server_url = "https://fideslog.ethyca.com"
+
     def __init__(
         self,
         client_id: str,
@@ -87,7 +89,7 @@ class AnalyticsClient:
 
         try:
             response = post(
-                "http://localhost:8080/events",
+                f"{self.server_url}/events",
                 json=payload,
                 timeout=(3.05, 120),
             )


### PR DESCRIPTION
Related to #7 
Blocked by #29 

For testing purposes, the SDK has been sending events to a server running on the user's `localhost`. The SDK should send events to production.