### PR TITLE
Rate limit requests

### DIFF
--- a/fideslog/api/main.py
+++ b/fideslog/api/main.py
@@ -5,14 +5,19 @@ from typing import Callable
 
 from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+from slowapi.extension import _rate_limit_exceeded_handler
 from uvicorn import run
 
 from fideslog.api.config import ServerSettings, config
+from fideslog.api.rate_limiter import rate_limiter
 from fideslog.api.routes.api import api_router
 
 log = logging.getLogger(__name__)
 
 app = FastAPI(title="fideslog")
+app.state.limiter = rate_limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.include_router(api_router)
 
 

--- a/fideslog/api/rate_limiter.py
+++ b/fideslog/api/rate_limiter.py
@@ -1,0 +1,4 @@
+from slowapi.extension import Limiter
+from slowapi.util import get_remote_address
+
+rate_limiter = Limiter(key_func=get_remote_address)

--- a/fideslog/api/requirements.txt
+++ b/fideslog/api/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.74.0
 pydantic==1.9.0
+slowapi==0.1.5
 snowflake-sqlalchemy==1.3.3
 sqlalchemy==1.4.31
 toml==0.10.2


### PR DESCRIPTION
Closes #26 

### API Changes
- Requests to the `/health` and `/events` endpoints are limited to a rate of 6 per minute
	- This is a generous limit, as it is only intended to prevent obvious spam