### PR TITLE
Include the SDK `README.md` in the `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include dev-requirements.txt
 include fideslog/sdk/python/_version.py
+include fideslog/sdk/python/README.md
 include fideslog/sdk/python/requirements.txt
 include versioneer.py


### PR DESCRIPTION
Third party tools cannot install fideslog via `pip` because the SDK's `README.md` is not included in the upload, but is referenced by the `setup.py` script.