### PR TITLE
Catch all exceptions and raise `AnalyticsError`s

### DIFF
--- a/fideslog/sdk/python/client.py
+++ b/fideslog/sdk/python/client.py
@@ -132,9 +132,9 @@ class AnalyticsClient:
                     "/events",
                     json=self.__get_request_payload(event),
                 ) as resp:
-                    try:
-                        resp.raise_for_status()
-                    except ClientResponseError as err:
-                        raise AnalyticsSendError(err.message, err.status) from err
+                    resp.raise_for_status()
+
             except ClientConnectionError as err:
                 raise UnreachableServerError(err.__str__()) from err
+            except ClientResponseError as err:
+                raise AnalyticsSendError(err.message, err.status) from err

--- a/fideslog/sdk/python/client.py
+++ b/fideslog/sdk/python/client.py
@@ -13,7 +13,12 @@ from aiohttp import (
 
 from . import __version__
 from .event import AnalyticsEvent
-from .exceptions import AnalyticsSendError, InvalidClientError, UnreachableServerError
+from .exceptions import (
+    AnalyticsSendError,
+    InvalidClientError,
+    UnknownError,
+    UnreachableServerError,
+)
 
 REQUIRED_HEADERS = {"X-Fideslog-Version": __version__}
 
@@ -66,8 +71,8 @@ class AnalyticsClient:
         Record a new event.
         """
 
-        # There is a Python bug in the default Windows event loop for Python 3.8+. This works around
-        # the issue by changing the default event loop for Windows.
+        # Works around a bug in the default Windows event loop for Python 3.8+
+        # by changing the default event loop in Windows processes.
         if (
             version_info[0] == 3
             and version_info[1] >= 8
@@ -138,3 +143,5 @@ class AnalyticsClient:
                 raise UnreachableServerError(err.__str__()) from err
             except ClientResponseError as err:
                 raise AnalyticsSendError(err.message, err.status) from err
+            except Exception as err:
+                raise UnknownError(err) from err

--- a/fideslog/sdk/python/client.py
+++ b/fideslog/sdk/python/client.py
@@ -4,11 +4,16 @@ from asyncio import run
 from sys import platform, version_info
 from typing import Dict, Optional
 
-from aiohttp import ClientResponseError, ClientSession, ClientTimeout
+from aiohttp import (
+    ClientConnectionError,
+    ClientResponseError,
+    ClientSession,
+    ClientTimeout,
+)
 
 from . import __version__
 from .event import AnalyticsEvent
-from .exceptions import AnalyticsSendError, InvalidClientError
+from .exceptions import AnalyticsSendError, InvalidClientError, UnreachableServerError
 
 REQUIRED_HEADERS = {"X-Fideslog-Version": __version__}
 
@@ -122,11 +127,14 @@ class AnalyticsClient:
             headers=REQUIRED_HEADERS,
             timeout=ClientTimeout(connect=3.05, total=120),
         ) as session:
-            async with session.post(
-                "/events",
-                json=self.__get_request_payload(event),
-            ) as resp:
-                try:
-                    resp.raise_for_status()
-                except ClientResponseError as err:
-                    raise AnalyticsSendError(err.message, err.status) from err
+            try:
+                async with session.post(
+                    "/events",
+                    json=self.__get_request_payload(event),
+                ) as resp:
+                    try:
+                        resp.raise_for_status()
+                    except ClientResponseError as err:
+                        raise AnalyticsSendError(err.message, err.status) from err
+            except ClientConnectionError as err:
+                raise UnreachableServerError(err.__str__()) from err

--- a/fideslog/sdk/python/exceptions.py
+++ b/fideslog/sdk/python/exceptions.py
@@ -45,6 +45,19 @@ class InvalidEventError(AnalyticsError):
         return f"Failed to initialize AnalyticsEvent: {self.message}"
 
 
+class UnknownError(AnalyticsError):
+    """
+    To be raised when an unforeseen error occurs.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self.message = error.__str__()
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return f"An unknown error occurred: {self.message}"
+
+
 class UnreachableServerError(AnalyticsError):
     """
     To be raised when a connection to the fideslog API server

--- a/fideslog/sdk/python/exceptions.py
+++ b/fideslog/sdk/python/exceptions.py
@@ -43,3 +43,17 @@ class InvalidEventError(AnalyticsError):
 
     def __str__(self) -> str:
         return f"Failed to initialize AnalyticsEvent: {self.message}"
+
+
+class UnreachableServerError(AnalyticsError):
+    """
+    To be raised when a connection to the fideslog API server
+    cannot be made.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return f"Failed to connect to the fideslog API server: {self.message}"


### PR DESCRIPTION
Closes #62 

### SDK Changes
- Adds `UnreachableServerError` and `UnknownError` types
- Catch `aiohttp`'s `ClientConnectionError` and raise an `UnreachableServerError`
- Catch any otherwise unhandled exception and raise an `UnknownError`