### PR TITLE
Rate limit all endpoints by default via middleware

### DIFF
--- a/fideslog/api/endpoints/events.py
+++ b/fideslog/api/endpoints/events.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 from ..database.data_access import create_event
 from ..database.database import get_db
 from ..models.analytics_event import AnalyticsEvent
-from ..rate_limiter import rate_limiter
 
 log = getLogger(__name__)
 router = APIRouter(tags=["Events"], prefix="/events")
@@ -29,7 +28,6 @@ router = APIRouter(tags=["Events"], prefix="/events")
     },
     status_code=status.HTTP_201_CREATED,
 )
-@rate_limiter.limit("6/minute")
 async def create(
     request: Request,  # pylint: disable=unused-argument
     event: AnalyticsEvent,

--- a/fideslog/api/endpoints/events.py
+++ b/fideslog/api/endpoints/events.py
@@ -20,7 +20,7 @@ router = APIRouter(tags=["Events"], prefix="/events")
         status.HTTP_429_TOO_MANY_REQUESTS: {
             "content": {
                 "application/json": {
-                    "example": {"error": "Rate limit exceeded: 6 per minute"}
+                    "example": {"error": "Rate limit exceeded: 20 per 1 minute"}
                 }
             },
             "description": "Rate limit exceeded",

--- a/fideslog/api/main.py
+++ b/fideslog/api/main.py
@@ -6,18 +6,20 @@ from typing import Callable
 from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
-from slowapi.extension import _rate_limit_exceeded_handler
+from slowapi.extension import Limiter, _rate_limit_exceeded_handler
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
 from uvicorn import run
 
 from fideslog.api.config import ServerSettings, config
-from fideslog.api.rate_limiter import rate_limiter
 from fideslog.api.routes.api import api_router
 
 log = logging.getLogger("fideslog.api.main")
 
 app = FastAPI(title="fideslog")
-app.state.limiter = rate_limiter
+app.state.limiter = Limiter(key_func=get_remote_address, default_limits=["6/minute"])
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 app.include_router(api_router)
 
 
@@ -26,8 +28,8 @@ app.include_router(api_router)
 async def require_version_header(request: Request, call_next: Callable) -> Response:
     """
     Enforce that the `X-Fideslog-Version` header was included on the request.
-    Does not apply to the `/docs`, `/openapi.json`, and `/redoc` endpoints,
-    to ensure that they remain publicly available.
+    Does not apply to the `/docs`, `/health`, `/openapi.json`, and `/redoc`
+    endpoints, to ensure that they remain publicly available.
 
     This header is intentionally undocumented, for mildly increased security.
     """

--- a/fideslog/api/main.py
+++ b/fideslog/api/main.py
@@ -17,7 +17,7 @@ from fideslog.api.routes.api import api_router
 log = logging.getLogger("fideslog.api.main")
 
 app = FastAPI(title="fideslog")
-app.state.limiter = Limiter(key_func=get_remote_address, default_limits=["6/minute"])
+app.state.limiter = Limiter(key_func=get_remote_address, default_limits=["20/minute"])
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
 app.include_router(api_router)

--- a/fideslog/api/rate_limiter.py
+++ b/fideslog/api/rate_limiter.py
@@ -1,4 +1,0 @@
-from slowapi.extension import Limiter
-from slowapi.util import get_remote_address
-
-rate_limiter = Limiter(key_func=get_remote_address)

--- a/fideslog/api/routes/api.py
+++ b/fideslog/api/routes/api.py
@@ -19,7 +19,7 @@ api_router.include_router(event_router)
         status.HTTP_429_TOO_MANY_REQUESTS: {
             "content": {
                 "application/json": {
-                    "example": {"error": "Rate limit exceeded: 6 per minute"}
+                    "example": {"error": "Rate limit exceeded: 20 per 1 minute"}
                 }
             },
             "description": "Rate limit exceeded",

--- a/fideslog/api/routes/api.py
+++ b/fideslog/api/routes/api.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
 
 from ..endpoints.events import router as event_router
-from ..rate_limiter import rate_limiter
 
 api_router = APIRouter()
 api_router.include_router(event_router)
@@ -28,7 +27,6 @@ api_router.include_router(event_router)
     },
     tags=["Health"],
 )
-@rate_limiter.limit("6/minute")
 async def health(request: Request) -> JSONResponse:  # pylint: disable=unused-argument
     """Confirm that the API is running and healthy."""
 


### PR DESCRIPTION
Closes #57

### API Changes
- Rate limit all endpoints by default via the `SlowAPIMiddleware`
  - Bumps the rate limit to 20/minute, as it's anticipated that 6/minute will be exceeded by legitimate use in the near term.
  - The affected endpoints have not changed. This change should be completely transparent to legitimate API consumers.
  - In the future, if an endpoint should be excluded from rate limiting, the `limiter` object can be restored and the `@limiter.exempt` decorator can be used. See: https://slowapi.readthedocs.io/en/latest/examples/#exempt-a-route-from-the-global-limit