### PR TITLE
Enable validation of events representing local servers

### DIFF
--- a/fideslog/api/models/analytics_event.py
+++ b/fideslog/api/models/analytics_event.py
@@ -96,6 +96,10 @@ class AnalyticsEvent(BaseModel):
     def validate_endpoint_format(cls, value: Optional[str]) -> Optional[str]:
         """
         Ensure that `endpoint` contains the request's HTTP method and URL.
+
+        If the URL contains the host `0.0.0.0` this validation would fail,
+        so it's replaced with `localhost` to ensure the URL can be legitimately
+        validated. The host is never stored in the databse, so it doesn't matter.
         """
 
         if value is None:
@@ -112,7 +116,9 @@ class AnalyticsEvent(BaseModel):
         ), f"HTTP method must be one of {', '.join(ALLOWED_HTTP_METHODS)}"
 
         url = endpoint_components[1].strip()
-        assert is_valid_url(url), "endpoint URL must be a valid URL"
+        assert is_valid_url(
+            url.replace("://0.0.0.0", "://localhost", 1)
+        ), "endpoint URL must be a valid URL"
 
         return f"{http_method}: {url}"
 

--- a/fideslog/sdk/python/event.py
+++ b/fideslog/sdk/python/event.py
@@ -94,7 +94,9 @@ class AnalyticsEvent:
                 ), f"HTTP method must be one of {', '.join(ALLOWED_HTTP_METHODS)}"
 
                 url = endpoint_components[1].strip()
-                assert is_valid_url(url), "endpoint URL must be a valid URL"
+                assert is_valid_url(
+                    url.replace("://0.0.0.0", "://localhost", 1)
+                ), "endpoint URL must be a valid URL"
 
                 self.endpoint = f"{http_method}: {url}"
 


### PR DESCRIPTION
When submitting events to the `/events` endpoint that represent API requests made by a server running locally (Ex. a host of `0.0.0.0`), the endpoint validation fails due to a bug in the third-party validation library.

These are legitimate events (or if they are illegitimate events, it is not due to this host value), so they should pass validation. The validator now simply replaces the `0.0.0.0` host with `localhost`. This does not affect event accuracy, because the endpoint URL is ultimately truncated such that it only includes the URL path.