### PR TITLE
Increase the request rate limit to 100/min

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,21 @@ If no configuration file is found in any of the above locations, the default con
 
 #### Options
 
-|     Name      | Configuration File Section |   Environment Variable Name    |  Type   | Required |     Default      | Description |
-|:-------------:|:--------------------------:|:------------------------------:|:-------:|:--------:|:----------------:|-------------|
-|   `account`   |        `[database]`        |  `FIDESLOG__DATABASE_ACCOUNT`   | String  |    Yes   |                  | The Snowflake account in which the fideslog database can be found. Ethyca employees may access this value internally. |
-|   `database`  |        `[database]`        |  `FIDESLOG__DATABASE_DATABASE`  | String  |    No    |      `"raw"`     | The name of the Snowflake database in which analytics events should be stored. |
-|  `db_schema`  |        `[database]`        | `FIDESLOG__DATABASE_DB_SCHEMA`  | String  |    No    |     `"fides"`    | The Snowflake database schema to target. |
-|  `password`   |        `[database]`        |  `FIDESLOG__DATABASE_PASSWORD`  | String  |    Yes   |                  | The password associated with the Snowflake account for `user`. Ethyca employees may access this value internally. |
-|    `role`     |        `[database]`        |    `FIDESLOG__DATABASE_ROLE`    | String  |    No    | `"event_writer"` | The permissions with which to access the specified Snowflake `database`.  |
-|    `user`     |        `[database]`        |    `FIDESLOG__DATABASE_USER`    | String  |    Yes   |                  | The ID of the user with which to authenticate to Snowflake. Ethyca employees may access this value internally. |
-|  `warehouse`  |        `[database]`        | `FIDESLOG__DATABASE_WAREHOUSE`  | String  |    No    |   `"fides_log"`  | The Snowflake data warehouse in which the fideslog database can be found. |
-| `destination` |        `[logging]`         | `FIDESLOG__LOGGING_DESTINATION` | String  |    No    |    `"stdout"`    | The absolute path to a file or directory in which logs should be stored. If a directory is passed, a `fideslog.log` file will be created in that directory. |
-|    `level`    |        `[logging]`         |    `FIDESLOG__LOGGING_LEVEL`    | String  |    No    |     `"INFO"`     | The desired logging level. Accepts `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. Case insensitive. |
-|    `host`     |         `[server]`         |     `FIDESLOG__SERVER_HOST`     | String  |    No    |    `"0.0.0.0"`   | The hostname on which the API server should respond. |
-| `hot_reload`  |         `[server]`         |  `FIDESLOG__SERVER_HOT_RELOAD`  | Boolean |    No    |      `False`     | Whether or not to automatically apply code changes during local development. |
-|    `port`     |         `[server]`         |     `FIDESLOG__SERVER_PORT`     | Integer |    No    |      `8080`      | The port number on which the API server should listen. |
+|        Name          | Configuration File Section |      Environment Variable Name        |  Type   | Required |     Default      | Description |
+|:--------------------:|:--------------------------:|:-------------------------------------:|:-------:|:--------:|:----------------:|-------------|
+|      `account`       |        `[database]`        |    `FIDESLOG__DATABASE_ACCOUNT`       | String  |    Yes   |                  | The Snowflake account in which the fideslog database can be found. Ethyca employees may access this value internally. |
+|      `database`      |        `[database]`        |    `FIDESLOG__DATABASE_DATABASE`      | String  |    No    |      `"raw"`     | The name of the Snowflake database in which analytics events should be stored. |
+|     `db_schema`      |        `[database]`        |   `FIDESLOG__DATABASE_DB_SCHEMA`      | String  |    No    |     `"fides"`    | The Snowflake database schema to target. |
+|     `password`       |        `[database]`        |    `FIDESLOG__DATABASE_PASSWORD`      | String  |    Yes   |                  | The password associated with the Snowflake account for `user`. Ethyca employees may access this value internally. |
+|       `role`         |        `[database]`        |      `FIDESLOG__DATABASE_ROLE`        | String  |    No    | `"event_writer"` | The permissions with which to access the specified Snowflake `database`.  |
+|       `user`         |        `[database]`        |      `FIDESLOG__DATABASE_USER`        | String  |    Yes   |                  | The ID of the user with which to authenticate to Snowflake. Ethyca employees may access this value internally. |
+|     `warehouse`      |        `[database]`        |   `FIDESLOG__DATABASE_WAREHOUSE`      | String  |    No    |   `"fides_log"`  | The Snowflake data warehouse in which the fideslog database can be found. |
+|    `destination`     |        `[logging]`         |   `FIDESLOG__LOGGING_DESTINATION`     | String  |    No    |    `"stdout"`    | The absolute path to a file or directory in which logs should be stored. If a directory is passed, a `fideslog.log` file will be created in that directory. |
+|       `level`        |        `[logging]`         |      `FIDESLOG__LOGGING_LEVEL`        | String  |    No    |     `"INFO"`     | The desired logging level. Accepts `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. Case insensitive. |
+|       `host `        |         `[server]`         |       `FIDESLOG__SERVER_HOST`         | String  |    No    |    `"0.0.0.0"`   | The hostname on which the API server should respond. |
+|    `hot_reload`      |         `[server]`         |     `FIDESLOG__SERVER_HOT_RELOAD`     | Boolean |    No    |      `False`     | Whether or not to automatically apply code changes during local development. |
+|       `port`         |         `[server]`         |        `FIDESLOG__SERVER_PORT`        | Integer |    No    |      `8080`      | The port number on which the API server should listen. |
+| `request_rate_limit` |         `[server]`         | `FIDESLOG__SERVER_REQUEST_RATE_LIMIT` | String  |    No    |  `"100/minute"`  | The amount of requests allowed per IP address per unit time. |
 
 #### Example Configuration File
 

--- a/fideslog/api/config.py
+++ b/fideslog/api/config.py
@@ -157,6 +157,7 @@ class ServerSettings(Settings):
     host: str = "localhost"
     hot_reload: bool = False
     port: int = 8080
+    request_rate_limit: str = "100/minute"
 
     class Config:
         """Modifies pydantic behavior."""

--- a/fideslog/api/endpoints/events.py
+++ b/fideslog/api/endpoints/events.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
+from ..config import config
 from ..database.data_access import create_event
 from ..database.database import get_db
 from ..models.analytics_event import AnalyticsEvent
@@ -20,7 +21,9 @@ router = APIRouter(tags=["Events"], prefix="/events")
         status.HTTP_429_TOO_MANY_REQUESTS: {
             "content": {
                 "application/json": {
-                    "example": {"error": "Rate limit exceeded: 20 per 1 minute"}
+                    "example": {
+                        "error": f"Rate limit exceeded: {config.server.request_rate_limit}"
+                    }
                 }
             },
             "description": "Rate limit exceeded",

--- a/fideslog/api/endpoints/events.py
+++ b/fideslog/api/endpoints/events.py
@@ -23,10 +23,32 @@ router = APIRouter(tags=["Events"], prefix="/events")
                 "application/json": {
                     "example": {
                         "error": f"Rate limit exceeded: {config.server.request_rate_limit}"
-                    }
+                    },
+                    "schema": {
+                        "type": "object",
+                        "properties": {"error": {"type": "string"}},
+                    },
                 }
             },
             "description": "Rate limit exceeded",
+            "headers": {
+                "Retry-After": {
+                    "description": "The datetime after which to retry the request.",
+                    "schema": {"type": "http-date"},
+                },
+                "X-RateLimit-Limit": {
+                    "description": "The number of allowed requests in the current period.",
+                    "schema": {"type": "integer"},
+                },
+                "X-RateLimit-Remaining": {
+                    "description": "The number of remaining requests in the current period.",
+                    "schema": {"type": "integer"},
+                },
+                "X-RateLimit-Reset": {
+                    "description": "The number of seconds left in the current period.",
+                    "schema": {"type": "integer"},
+                },
+            },
         }
     },
     status_code=status.HTTP_201_CREATED,

--- a/fideslog/api/main.py
+++ b/fideslog/api/main.py
@@ -17,7 +17,12 @@ from fideslog.api.routes.api import api_router
 log = logging.getLogger("fideslog.api.main")
 
 app = FastAPI(title="fideslog")
-app.state.limiter = Limiter(key_func=get_remote_address, default_limits=["20/minute"])
+app.state.limiter = Limiter(
+    default_limits=[config.server.request_rate_limit],
+    headers_enabled=True,
+    key_func=get_remote_address,
+    retry_after="http-date",
+)
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
 app.include_router(api_router)

--- a/fideslog/api/routes/api.py
+++ b/fideslog/api/routes/api.py
@@ -3,6 +3,7 @@ from typing import Dict
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
 
+from ..config import config
 from ..endpoints.events import router as event_router
 
 api_router = APIRouter()
@@ -19,7 +20,9 @@ api_router.include_router(event_router)
         status.HTTP_429_TOO_MANY_REQUESTS: {
             "content": {
                 "application/json": {
-                    "example": {"error": "Rate limit exceeded: 20 per 1 minute"}
+                    "example": {
+                        "error": f"Rate limit exceeded: {config.server.request_rate_limit}"
+                    }
                 }
             },
             "description": "Rate limit exceeded",

--- a/fideslog/api/routes/api.py
+++ b/fideslog/api/routes/api.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from fastapi import APIRouter, Request, status
 from fastapi.responses import JSONResponse
 
@@ -12,20 +10,49 @@ api_router.include_router(event_router)
 
 @api_router.get(
     "/health",
-    response_model=Dict[str, str],
     responses={
         status.HTTP_200_OK: {
-            "content": {"application/json": {"example": {"status": "healthy"}}},
+            "content": {
+                "application/json": {
+                    "example": {"status": "healthy"},
+                    "schema": {
+                        "type": "object",
+                        "properties": {"status": {"type": "string"}},
+                    },
+                }
+            }
         },
         status.HTTP_429_TOO_MANY_REQUESTS: {
             "content": {
                 "application/json": {
                     "example": {
                         "error": f"Rate limit exceeded: {config.server.request_rate_limit}"
-                    }
+                    },
+                    "schema": {
+                        "type": "object",
+                        "properties": {"error": {"type": "string"}},
+                    },
                 }
             },
             "description": "Rate limit exceeded",
+            "headers": {
+                "Retry-After": {
+                    "description": "The datetime after which to retry the request.",
+                    "schema": {"type": "http-date"},
+                },
+                "X-RateLimit-Limit": {
+                    "description": "The number of allowed requests in the current period.",
+                    "schema": {"type": "integer"},
+                },
+                "X-RateLimit-Remaining": {
+                    "description": "The number of remaining requests in the current period.",
+                    "schema": {"type": "integer"},
+                },
+                "X-RateLimit-Reset": {
+                    "description": "The number of seconds left in the current period.",
+                    "schema": {"type": "integer"},
+                },
+            },
         },
     },
     tags=["Health"],


### PR DESCRIPTION
Closes #73 

- The request rate limit is now configurable via the `FIDESLOG__SERVER_REQUEST_RATE_LIMIT` ENV variable or:
    ```toml
    # fideslog.toml

    [server]
    request_rate_limit = "100/minute"
    ```
  - Defaults to 100 requests per minute
  - Affects all endpoints
- The following headers are now included in 429 responses:
  - `Retry-After`:  The datetime after which to retry the request
  - `X-RateLimit-Limit`: The number of allowed requests in the current period
  - `X-RateLimit-Remaining`: The number of remaining requests in the current period
  - `X-RateLimit-Reset`: The number of seconds left in the current period
- Response schemas are now explicitly documented