### PR TITLE
Expose async send

### DIFF
--- a/fideslog/sdk/python/client.py
+++ b/fideslog/sdk/python/client.py
@@ -85,7 +85,7 @@ class AnalyticsClient:
 
             set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
-        run(self.__send(event))
+        run(self.async_send(event))
 
     def __get_request_payload(self, event: AnalyticsEvent) -> Dict:
         """
@@ -122,7 +122,7 @@ class AnalyticsClient:
 
         return payload
 
-    async def __send(self, event: AnalyticsEvent) -> None:
+    async def async_send(self, event: AnalyticsEvent) -> None:
         """
         Asynchronously record a new `AnalyticsEvent`.
         """


### PR DESCRIPTION
Closes #71

This is to exposes the async send to external callers. By allowing this, when async programs are running they use their own even loop rather than having 2 loops start. In my testing this solved the issue in #71.

I left the `send` option also so non-async programs (ie fidesctl with Click) can still call it as they have been.