### PR TITLE
Fix module not found error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   fideslog:
     image: ethyca/fideslog:local
-    command: [ "python", "fideslog/api/main.py" ]
+    command: [ "python", "-m", "fideslog.api.main" ]
     healthcheck:
       test: [ "CMD", "curl", "--fail", "http://0.0.0.0:8080/health" ]
       interval: 1m30s


### PR DESCRIPTION
Fixes the module not found error when running `make api`