### PR TITLE
Include the `api/requirements.txt` file in the PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ graft fideslog/sdk/python
 include dev-requirements.txt
 include versioneer.py
 prune fideslog/api
+include fideslog/api/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup
 
 from versioneer import get_cmdclass, get_version
 
-api_requires = open("./fideslog/api/requirements.txt").read().strip().split("\n")
 sdk_requires = open("./fideslog/sdk/python/requirements.txt").read().strip().split("\n")
 dev_requires = open("./dev-requirements.txt").read().strip().split("\n")
 
@@ -11,7 +10,7 @@ setup(
     version=get_version(),
     cmdclass=get_cmdclass(),
     description="The fideslog analytics collection mechanism",
-    long_description=open("./README.md").read(),
+    long_description=open("./fideslog/sdk/python/README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/ethyca/fideslog",
     python_requires=">=3.8, <4",
@@ -26,7 +25,7 @@ setup(
     author="Ethyca, Inc.",
     author_email="fidesteam@ethyca.com",
     license="Apache License 2.0",
-    install_requires=api_requires + sdk_requires,
+    install_requires=sdk_requires,
     dev_requires=dev_requires,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Fixes an error on `pip install fideslog` where the `api/requirements.txt` file is not found.