### PR TITLE
Default `Registration` datetimes to `now()`, expose `send_async()`

### DIFF
--- a/fideslog/api/database/registrations.py
+++ b/fideslog/api/database/registrations.py
@@ -38,8 +38,8 @@ def create(database: Session, registration: Registration) -> None:
             client_id=registration.client_id,
             email=registration.email,
             organization=registration.organization,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=registration.created_at,
+            updated_at=registration.updated_at,
         )
     )
 

--- a/fideslog/api/schemas/registration.py
+++ b/fideslog/api/schemas/registration.py
@@ -1,6 +1,6 @@
 # pylint: disable= no-self-argument, no-self-use
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel, EmailStr, Field, validator
 
@@ -23,11 +23,11 @@ class Registration(BaseModel):
         description="The organization in which the user is registered.",
     )
     created_at: datetime = Field(
-        None,
+        datetime.now(tz=timezone.utc),
         description="The UTC timestamp when the registration occurred, in ISO 8601 format. Must include the UTC timezone, and represent a datetime in the past.",
     )
     updated_at: datetime = Field(
-        None,
+        datetime.now(tz=timezone.utc),
         description="The UTC timestamp when the registration was last updated, in ISO 8601 format. Must include the UTC timezone, and represent a datetime in the past.",
     )
 

--- a/fideslog/sdk/python/registration.py
+++ b/fideslog/sdk/python/registration.py
@@ -8,12 +8,20 @@ class Registration:
     Represents a user registering their information.
     """
 
-    def __init__(self, email: str, organization: str) -> None:
+    def __init__(
+        self,
+        email: str,
+        organization: str,
+        created_at: datetime = datetime.now(tz=timezone.utc),
+        updated_at: datetime = datetime.now(tz=timezone.utc),
+    ) -> None:
         """
         Define a new user registration.
 
         :param email: The user's email address.
         :param organization: The user's organization.
+        :param created_at: The UTC timestamp when the registration occurred, in ISO 8601 format. Must include the UTC timezone, and represent a datetime in the past.
+        :param updated_at: The UTC timestamp when the registration was last updated, in ISO 8601 format. Must include the UTC timezone, and represent a datetime in the past.
         """
 
         try:
@@ -23,8 +31,8 @@ class Registration:
             assert len(organization) > 0, "organization must be provided"
             self.organization = organization
 
-            self.created_at = datetime.now(timezone.utc)
-            self.updated_at = datetime.now(timezone.utc)
+            self.created_at = created_at
+            self.updated_at = updated_at
 
         except AssertionError as err:
             raise InvalidEventError(str(err)) from None


### PR DESCRIPTION
- Fixes a bug where request payloads sent to the `POST /registrations` endpoint failed validation
- Exposes `send_async()` in lieu of `__send()`