### PR TITLE
Remove `__set_event_loop()`

### DIFF
--- a/fideslog/sdk/python/client.py
+++ b/fideslog/sdk/python/client.py
@@ -1,7 +1,6 @@
 # pylint: disable=import-outside-toplevel, too-many-arguments
 
 from asyncio import run
-from sys import platform, version_info
 from typing import Dict, Optional, Union
 
 from aiohttp import (
@@ -22,25 +21,6 @@ from .exceptions import (
 from .registration import Registration
 
 REQUIRED_HEADERS = {"X-Fideslog-Version": __version__}
-
-
-def __set_event_loop() -> None:
-    """
-    Helps to work around a bug in the default Windows event loop for Python 3.8+
-    by changing the default event loop in Windows processes.
-    """
-
-    if (
-        version_info[0] == 3
-        and version_info[1] >= 8
-        and platform.lower().startswith("win")
-    ):
-        from asyncio import (  # type: ignore[attr-defined]
-            WindowsSelectorEventLoopPolicy,
-            set_event_loop_policy,
-        )
-
-        set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
 
 class AnalyticsClient:
@@ -91,7 +71,6 @@ class AnalyticsClient:
         Register a new user.
         """
 
-        __set_event_loop()
         run(self.send_async(registration))
 
     async def register_async(self, registration: Registration) -> None:
@@ -106,7 +85,6 @@ class AnalyticsClient:
         Record a new analytics event.
         """
 
-        __set_event_loop()
         run(self.send_async(event))
 
     async def send_async(


### PR DESCRIPTION
Per the Python documentation, `asyncio.ProactorEventLoop` is used by default on Windows as of Python 3.8. Python 3.8 is the minimum supported version for this repository.