### PR TITLE
Downgrade twine to attempt to fix error in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Twine
-        run: pip install twine
+        run: pip install twine==6.0.1
 
       - name: Twine Upload
         run: |

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -6,7 +6,8 @@ on:
       - main
     paths:
       - fideslog/**
-      - .github/workflows/pr_checks.yaml
+      - .github/workflows/pr_checks.yml
+      - .github/workflows/deploy.yml
 
 env:
   CONTAINER: fideslog-local


### PR DESCRIPTION
### Description 

When we run the deployment action to publish to pypi, we're getting an [InvalidDistribution error](https://github.com/ethyca/fideslog/actions/runs/13703836725/job/38324164061).  This is an [issue](https://github.com/pypa/twine/issues/1216)  with the latest Twine version , and users reported that downgrading to 6.0.1 works . 