### PR TITLE
bump aiohttp to its latest version (`3.12.15`)

### DIFF
--- a/fideslog/sdk/python/requirements.txt
+++ b/fideslog/sdk/python/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp[speedups]==3.8.1
+aiohttp[speedups]==3.12.15
 bcrypt~=3.2.0
 types-requests==2.27.11
 validators==0.34.0


### PR DESCRIPTION
We were pinning to an old version of `aiohttp` that is causing conflicts in downstream projects (`fidesplus`) that have dependencies that have requirements for e.g. `aiohttp>=3.10`