### PR TITLE
update pycares and aiodns

### DIFF
--- a/fideslog/sdk/python/requirements.txt
+++ b/fideslog/sdk/python/requirements.txt
@@ -1,6 +1,7 @@
+aiodns==3.5.0
 aiohttp[speedups]==3.12.15
 bcrypt~=3.2.0
-pycares>=4.5.0
+pycares==4.9.0
 types-requests==2.27.11
 validators==0.34.0
 versioneer==0.19

--- a/fideslog/sdk/python/requirements.txt
+++ b/fideslog/sdk/python/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp[speedups]==3.12.15
 bcrypt~=3.2.0
+pycares>=4.5.0
 types-requests==2.27.11
 validators==0.34.0
 versioneer==0.19


### PR DESCRIPTION
We weren't pinning a version of `aiodns` or `pycares` which have some version compatibility conflicts causing transitive dependency issues in downstream projects (fides) 

Both are pinned in this PR 